### PR TITLE
Optionally allow caller to provide minimatch options (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,35 @@ gulp.src('**/*.js')
   .pipe(jshint());
 ```
 
+`.gitignore` is used by default. However, you can specify a different file:
+
+```js
+gulp.src('**/*.js')
+  .pipe(excludeGitignore('custom.gitignore'))
+  .pipe(jshint());
+```
+
+If you use custom [minimatch][minimatch-url] options in your glob, you can pass those if needed to ensure correct behavior:
+
+```js
+gulp.src('**/*.json', {dot: true})
+  .pipe(excludeGitignore({dot: true}))
+  .pipe(jshint());
+```
+
+## API
+
+### excludeGitignore([gitignorePath][, minimatchOptions])
+
+Default export. Excludes all files that are matched by the specified gitignore file.
+
+#### gitignorePath
+
+Optional; defaults to `.gitignore`.
+
+#### minimatchOptions
+
+Optional; defaults to `{}`. These options are passed to [minimatch][minimatch-url].
 
 ## License
 
@@ -35,3 +64,4 @@ ISC © [Simon Boudrias](http://simonboudrias.com)
 [daviddm-url]: https://david-dm.org/SBoudrias/gulp-exclude-gitignore
 [coveralls-image]: https://coveralls.io/repos/SBoudrias/gulp-exclude-gitignore/badge.svg
 [coveralls-url]: https://coveralls.io/r/SBoudrias/gulp-exclude-gitignore
+[minimatch-url]: https://github.com/isaacs/minimatch

--- a/README.md
+++ b/README.md
@@ -21,35 +21,6 @@ gulp.src('**/*.js')
   .pipe(jshint());
 ```
 
-`.gitignore` is used by default. However, you can specify a different file:
-
-```js
-gulp.src('**/*.js')
-  .pipe(excludeGitignore('custom.gitignore'))
-  .pipe(jshint());
-```
-
-If you use custom [minimatch][minimatch-url] options in your glob, you can pass those if needed to ensure correct behavior:
-
-```js
-gulp.src('**/*.json', {dot: true})
-  .pipe(excludeGitignore({dot: true}))
-  .pipe(jshint());
-```
-
-## API
-
-### excludeGitignore([gitignorePath][, minimatchOptions])
-
-Default export. Excludes all files that are matched by the specified gitignore file.
-
-#### gitignorePath
-
-Optional; defaults to `.gitignore`.
-
-#### minimatchOptions
-
-Optional; defaults to `{}`. These options are passed to [minimatch][minimatch-url].
 
 ## License
 
@@ -64,4 +35,3 @@ ISC © [Simon Boudrias](http://simonboudrias.com)
 [daviddm-url]: https://david-dm.org/SBoudrias/gulp-exclude-gitignore
 [coveralls-image]: https://coveralls.io/repos/SBoudrias/gulp-exclude-gitignore/badge.svg
 [coveralls-url]: https://coveralls.io/r/SBoudrias/gulp-exclude-gitignore
-[minimatch-url]: https://github.com/isaacs/minimatch

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,13 @@ var appendStars = function (dirname, str) {
   ];
 };
 
-module.exports = function (gitignorePath) {
+module.exports = function (gitignorePath, minimatchOptions) {
+  if (typeof gitignorePath === 'object') {
+    minimatchOptions = gitignorePath;
+    gitignorePath = undefined;
+  }
   gitignorePath = path.resolve(gitignorePath || '.gitignore');
+  minimatchOptions = minimatchOptions || {};
   var dirname = path.dirname(path.relative(process.cwd(), gitignorePath));
   if (dirname === '.') {
     dirname = '';
@@ -32,5 +37,5 @@ module.exports = function (gitignorePath) {
       return m.concat(paths);
     }, []);
 
-  return gulpIgnore.exclude(ignoredFiles);
+  return gulpIgnore.exclude(ignoredFiles, minimatchOptions);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,13 +14,8 @@ var appendStars = function (dirname, str) {
   ];
 };
 
-module.exports = function (gitignorePath, minimatchOptions) {
-  if (typeof gitignorePath === 'object') {
-    minimatchOptions = gitignorePath;
-    gitignorePath = undefined;
-  }
+module.exports = function (gitignorePath) {
   gitignorePath = path.resolve(gitignorePath || '.gitignore');
-  minimatchOptions = minimatchOptions || {};
   var dirname = path.dirname(path.relative(process.cwd(), gitignorePath));
   if (dirname === '.') {
     dirname = '';
@@ -37,5 +32,5 @@ module.exports = function (gitignorePath, minimatchOptions) {
       return m.concat(paths);
     }, []);
 
-  return gulpIgnore.exclude(ignoredFiles, minimatchOptions);
+  return gulpIgnore.exclude(ignoredFiles, {dot: true});
 };

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,32 @@ describe('gulp-exclude-gitignore', function () {
     stream.end();
   });
 
+  it('excludes dot files contained in .gitignore', function (done) {
+    var stream = excludeGitignore({dot: true});
+
+    var filePaths = [];
+    stream.on('data', function (file) {
+      filePaths.push(file.relative);
+    });
+
+    stream.on('finish', function () {
+      assert.deepEqual(filePaths, [
+        '.a.txt',
+        'baz/.e.txt',
+        'baz/f.txt'
+      ]);
+      done();
+    });
+
+    stream.write(fakeFile('.a.txt'));
+    stream.write(fakeFile('b.txt'));
+    stream.write(fakeFile('foo/.c.txt'));
+    stream.write(fakeFile('foo/d.txt'));
+    stream.write(fakeFile('baz/.e.txt'));
+    stream.write(fakeFile('baz/f.txt'));
+    stream.end();
+  });
+
   it('excludes files contained in the provided file', function (done) {
     var stream = excludeGitignore('custom.gitignore');
 

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,7 @@ describe('gulp-exclude-gitignore', function () {
   });
 
   it('excludes dot files contained in .gitignore', function (done) {
-    var stream = excludeGitignore({dot: true});
+    var stream = excludeGitignore();
 
     var filePaths = [];
     stream.on('data', function (file) {


### PR DESCRIPTION
This PR addresses issue #6.

`excludeGitignore()` was modified to accept a second parameter, `minimatchOptions`, that has a default value of `{}`.  These options will be passed to gulp-ignore and ultimately passed to minimatch itself.  The motivation for this new parameter is documented in the use case provided in issue #6.

I also modified `excludeGitignore()` so the caller can specify zero arguments, one argument containing `gitignorePath`, one argument containing `minimatchOptions`, or two arguments in the order `gitignorePath` followed by `minimatchOptions`.  The README has been updated to reflect the new usage.

The new test case fails if you omit the minimatch options or specify `{dot: false}`.

I believe this change will require a minor version bump.